### PR TITLE
fix: CI/CD now properly detects marked-annotated-hexdump

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -8,10 +8,10 @@ module.exports = {
         releaseRules: [
           {
             type: "chore",
-            scope: "marked-annotated-hexdump",
-            release: "patch",
+            scope: "deps",
+            subject: "*marked-annotated-hexdump*",
+            release: "minor",
           },
-          { type: "chore", scope: "*", release: false },
         ],
         parserOpts: {
           noteKeywords: ["BREAKING CHANGE", "BREAKING CHANGES"],


### PR DESCRIPTION
This now triggers a minor release. Previously it was overriden by the trailing rule.